### PR TITLE
check for undefined is missing

### DIFF
--- a/codebase/sources/dhtmlxscheduler.js
+++ b/codebase/sources/dhtmlxscheduler.js
@@ -5730,7 +5730,7 @@ scheduler._init_touch_events = function(){
 		} else
 			this._touch_events(["touchmove", "touchstart", "touchend"], function(ev){
 				if (ev.touches && ev.touches.length > 1) return null;
-				if (ev.touches[0])
+				if (ev.touches && ev.touches[0])
 					return { target:ev.target, pageX:ev.touches[0].pageX, pageY:ev.touches[0].pageY };
 				else 
 					return ev;


### PR DESCRIPTION
On some mobile devices `ev.touches` is set to `undefined`, causing a lot of exceptions, when accessing the `touches` property:

    ev.touches[0] => undefined is not an object (evaluating 'ev.touches')

This exception is not critical, but it will flood client-side javascript logs with a lot of unnecessary exceptions.