### PR TITLE
Make it possible to target expanded scheduler with CSS selectors

### DIFF
--- a/codebase/sources/ext/dhtmlxscheduler_expand.js
+++ b/codebase/sources/ext/dhtmlxscheduler_expand.js
@@ -14,6 +14,7 @@ scheduler.expand = function() {
 	if(!scheduler.callEvent("onBeforeExpand", []))
 		return;
 	var t = scheduler._obj;
+	t.className += " dhx_scheduler_expanded";
 	do {
 		t._position = t.style.position || "";
 		t.style.position = "static";
@@ -40,6 +41,7 @@ scheduler.collapse = function() {
 	if(!scheduler.callEvent("onBeforeCollapse", []))
 		return;
 	var t = scheduler._obj;
+	t.className = t.className.replace("dhx_scheduler_expanded", "").replace("  "," ");
 	do {
 		t.style.position = t._position;
 	} while ((t = t.parentNode) && t.style);


### PR DESCRIPTION
Currently it is not possible to apply a different style to the scheduler based on the state of the expand plugin via CSS selectors, because all changes are made by modifying style properties directly. This change will add `dhx_scheduler_expanded` class every time the scheduler is expanded and remove it, when the scheduler is collapsed. I didn't use the `classList` property, so it should work even with older browsers. After the change, scheduler styling can be modified via CSS selectors like this:
```css
.dhx_scheduler_expanded .dhx_cal_date {
  font-size: 20px;
}
```