### PR TITLE
Config multi day always visible

### DIFF
--- a/codebase/dhtmlxscheduler.d.ts
+++ b/codebase/dhtmlxscheduler.d.ts
@@ -868,6 +868,11 @@ export interface SchedulerConfigOptions {
 	multi_day_height_limit: number|boolean;
 
 	/**
+	 * always render the multi-day header
+	*/
+	multi_day_always_visible: boolean;
+
+	/**
 	 * enables the possibility to render the same events in several sections of the Timeline or Units view
 	*/
 	multisection: boolean;

--- a/codebase/sources/dhtmlxscheduler.js
+++ b/codebase/sources/dhtmlxscheduler.js
@@ -5435,6 +5435,7 @@ scheduler.config={
 
 	multi_day:true,
 	multi_day_height_limit: 0,
+	multi_day_always_visible: false,
 
 	drag_lightbox: true,
 	preserve_scroll: true,
@@ -5988,7 +5989,7 @@ scheduler._pre_render_events = function(evs, hold) {
 			} else {
 				if (!evs.length && this._els["dhx_multi_day"][0].style.visibility == "visible")
 					h[0] = -1;
-				if (evs.length || h[0] == -1) {
+				if (evs.length || h[0] == -1 || this.config.multi_day_always_visible) {
 					//shift days to have space for multiday events
 					var childs = evl.parentNode.childNodes;
 


### PR DESCRIPTION
Add config option `multi_day_always_visible` (Type: `boolean `/ Default: `false`).

Some people would like to have the `dhx_multi_day` header always shown, even it the day/week doesn't have any all-day/multi-day events.