### PR TITLE
Remove css warning

### DIFF
--- a/codebase/sources/skins/dhtmlxscheduler_terrace.css
+++ b/codebase/sources/skins/dhtmlxscheduler_terrace.css
@@ -548,7 +548,7 @@ div.icon_delete {
   white-space: nowrap;
   display: flex;
   flex-direction: row;
-  justify-content: start;
+  justify-content: flex-start;
 }
 .dhx_cal_ltext.dhx_cal_template {
   position: relative;


### PR DESCRIPTION
`autoprefixer: start value has mixed support, consider using flex-start instead`